### PR TITLE
Add location setup and manual RA/Dec goto

### DIFF
--- a/storage.h
+++ b/storage.h
@@ -10,6 +10,9 @@ struct SystemConfig {
   AxisCalibration axisCalibration;
   BacklashConfig backlash;
   GotoProfile gotoProfile;
+  double observerLatitudeDeg;
+  double observerLongitudeDeg;
+  int32_t timezoneOffsetMinutes;
   bool joystickCalibrated;
   bool axisCalibrated;
   bool polarAligned;
@@ -26,6 +29,7 @@ void setBacklash(const BacklashConfig& backlash);
 void setGotoProfile(const GotoProfile& profile);
 void setPolarAligned(bool aligned);
 void setRtcEpoch(uint32_t epoch);
+void setObserverLocation(double latitudeDeg, double longitudeDeg, int32_t timezoneMinutes);
 void save();
 bool isSdAvailable();
 


### PR DESCRIPTION
## Summary
- add a setup submenu to edit and persist observer latitude, longitude, and timezone in EEPROM
- update sidereal and coordinate transforms to use the stored observer settings instead of fixed constants
- add a main menu entry for manual goto with an RA/Dec editor that launches gotos to user-entered coordinates

## Testing
- not run (embedded firmware; no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68e5fa85a34c832bb640df76398622cd