### PR TITLE
Delay SD initialization error until timeout

### DIFF
--- a/config.h
+++ b/config.h
@@ -35,6 +35,10 @@ constexpr uint8_t SCL_PIN = 22;
 // SD card chip select
 constexpr uint8_t SD_CS_PIN = 5;
 
+// SD card initialization behavior
+constexpr uint32_t SD_INIT_TIMEOUT_MS = 1500;
+constexpr uint16_t SD_INIT_RETRY_DELAY_MS = 100;
+
 // Driver configuration
 constexpr float R_SENSE = 0.11f;
 constexpr uint8_t DRIVER_ADDR_RA = 0b00;

--- a/storage.cpp
+++ b/storage.cpp
@@ -1,5 +1,6 @@
 #include "storage.h"
 
+#include <Arduino.h>
 #include <EEPROM.h>
 #include <SD.h>
 #include <SPI.h>
@@ -89,7 +90,17 @@ bool init() {
     }
   }
 
-  sdAvailable = SD.begin(config::SD_CS_PIN);
+  const uint32_t start = millis();
+  do {
+    sdAvailable = SD.begin(config::SD_CS_PIN);
+    if (sdAvailable) {
+      break;
+    }
+    if (millis() - start >= config::SD_INIT_TIMEOUT_MS) {
+      break;
+    }
+    delay(config::SD_INIT_RETRY_DELAY_MS);
+  } while (true);
   return sdAvailable;
 }
 


### PR DESCRIPTION
## Summary
- add configuration for SD card initialization timeout and retry delay
- retry SD initialization until the timeout elapses before reporting failure

## Testing
- not run (hardware-dependent)


------
https://chatgpt.com/codex/tasks/task_e_68e6050d1978832bb7b76dba4c958ca4